### PR TITLE
Add css sourceMap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function getModules() {
         ],
         loaders: {
           css: ExtractTextPlugin.extract({
-            loader: `css-loader`,
+            loader: `css-loader?sourceMap`,
             fallbackLoader: 'vue-style-loader'
           })
         }
@@ -196,7 +196,7 @@ exports.build = function ({
   return {
     context: path.resolve(inputRootPath),
     target: isServer ? 'node' : 'web',
-    devtool: !isServer && isDev ? '#eval-source-map' : false,
+    devtool: !isServer && isDev ? '#source-map' : false,
     module: getModules(),
     entry: getEntry({inputFilePath, hotReload}),
     output: getOutput({isServer, outputPath, outputFileName, publicPath}),


### PR DESCRIPTION
With this patch we can enable sourceMaps for css.

The provided [option](https://github.com/vuejs/vue-loader/blob/master/docs/en/options.md#csssourcemap) by 'vue-loader' for enabling css sourceMaps apparently not working when css is extracted with webpack 'ExtractTextPlugin'.

Also, css sourceMaps are not generated when Webpack.devTool option is set to 'eval-source-map'. With changing it to 'source-map' we trade-off some built time in favor for a better CSS debugging. 