### PR TITLE
Added postcss-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "file-loader": "^0.9.0",
     "inline-environment-variables-webpack-plugin": "^1.1.0",
     "postcss-cssnext": "^2.8.0",
+    "postcss-import": "8.1.0",
     "vue-loader": "^10.0.0",
     "vue-template-compiler": "^2.1.0",
     "webpack": "^2.1.0-beta.27",
@@ -53,8 +54,8 @@
   },
   "peerDependencies": {
     "extract-text-webpack-plugin": "^2.0.0-beta.4",
-    "inline-environment-variables-webpack-plugin": "^1.1.0",
     "file-loader": "^0.9.0",
+    "inline-environment-variables-webpack-plugin": "^1.1.0",
     "postcss-cssnext": "^2.8.0",
     "vue-loader": "^10.0.0",
     "webpack": "^2.1.0-beta.27",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const ManifestPlugin = require('webpack-manifest-plugin');
 const InlineEnviromentVariablesPlugin = require('inline-environment-variables-webpack-plugin');
 const cssNext = require('postcss-cssnext');
+const postcssImport = require('postcss-import');
 
 /*
 * Returns a modules object.
@@ -16,6 +17,7 @@ function getModules() {
       loader: 'vue-loader',
       options: {
         postcss: [
+          postcssImport(),
           cssNext()
         ],
         loaders: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,11 +1264,11 @@ color-convert@^1.3.0:
   dependencies:
     color-name "^1.1.1"
 
-color-name@1.0.x:
+color-name@1.0.x, color-name@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.0.1.tgz#6b34b2b29b7716013972b0b9d5bedcfbb6718df8"
 
-color-name@^1.0.0, color-name@^1.1.1:
+color-name@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
@@ -3002,7 +3002,7 @@ pbkdf2@^3.0.3:
   dependencies:
     create-hmac "^1.1.2"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -3249,6 +3249,16 @@ postcss-font-variant@^2.0.0:
   resolved "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz#7ca29103f59fa02ca3ace2ca22b2f756853d4ef8"
   dependencies:
     postcss "^5.0.4"
+
+postcss-import@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-8.1.0.tgz#4027f5f37c20b3953c7b30f9a8bfeec20a3cc14c"
+  dependencies:
+    object-assign "^4.0.1"
+    postcss "^5.0.14"
+    postcss-value-parser "^3.2.3"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
 
 postcss-initial@^1.3.1:
   version "1.5.2"
@@ -3644,6 +3654,12 @@ read-all-stream@^3.0.0:
     pinkie-promise "^2.0.0"
     readable-stream "^2.0.0"
 
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  dependencies:
+    pify "^2.3.0"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -3844,7 +3860,7 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.1.6:
+resolve@^1.1.6, resolve@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 


### PR DESCRIPTION
In order to import css definitions from local files, node modules or web_modules while using postcss, we need to include this [plugin](https://github.com/postcss/postcss-import). It will inline @import rules content into a Vue component.

```
<style>
/*Importing css from npm module*/
@import "normalize.css";
/*Importing css from project folder. Useful for project css variables.*/
@import "./styles/variables.css";

body{
  background-color: var(--mainColor);
  @apply --centered;
}

</style>
```